### PR TITLE
chore: migrate to Bevy 0.19-dev

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ std = ["bevy_math/std", "glam_matrix_extras/std"]
 # Math
 approx = { version = "0.5", optional = true }
 bevy_math = { git = "https://github.com/bevyengine/bevy", default-features = false }
-glam_matrix_extras = { git = "https://github.com/Jondolf/glam_matrix_extras", branch = "bsn", default-features = false, features = [
+glam_matrix_extras = { git = "https://github.com/jbuehler23/glam_matrix_extras", branch = "bsn", default-features = false, features = [
     "f32",
 ] }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,13 +47,13 @@ std = ["bevy_math/std", "glam_matrix_extras/std"]
 [dependencies]
 # Math
 approx = { version = "0.5", optional = true }
-bevy_math = { version = "0.18.0", default-features = false }
-glam_matrix_extras = { version = "0.2", default-features = false, features = [
+bevy_math = { git = "https://github.com/bevyengine/bevy", default-features = false }
+glam_matrix_extras = { git = "https://github.com/jbuehler23/glam_matrix_extras", branch = "bsn", default-features = false, features = [
     "f32",
 ] }
 
 # Serialization
-bevy_reflect = { version = "0.18.0", default-features = false, optional = true }
+bevy_reflect = { git = "https://github.com/bevyengine/bevy", default-features = false, optional = true }
 serde = { version = "1.0", default-features = false, optional = true }
 
 [dev-dependencies]
@@ -62,7 +62,7 @@ bevy_heavy = { path = ".", features = ["approx"] }
 
 # Math
 approx = { version = "0.5", default-features = false }
-bevy_math = { version = "0.18.0", default-features = false, features = [
+bevy_math = { git = "https://github.com/bevyengine/bevy", default-features = false, features = [
     "std",
     "approx",
     "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ std = ["bevy_math/std", "glam_matrix_extras/std"]
 # Math
 approx = { version = "0.5", optional = true }
 bevy_math = { git = "https://github.com/bevyengine/bevy", default-features = false }
-glam_matrix_extras = { git = "https://github.com/jbuehler23/glam_matrix_extras", branch = "bsn", default-features = false, features = [
+glam_matrix_extras = { git = "https://github.com/Jondolf/glam_matrix_extras", branch = "bsn", default-features = false, features = [
     "f32",
 ] }
 


### PR DESCRIPTION
Bump bevy_math, bevy_reflect, and glam_matrix_extras to Bevy 0.19-dev.